### PR TITLE
fix: use cluster role for access to secrets

### DIFF
--- a/deploy/charts/harbor-container-webhook/templates/rbac.yaml
+++ b/deploy/charts/harbor-container-webhook/templates/rbac.yaml
@@ -10,6 +10,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,29 +30,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "harbor-container-webhook.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "harbor-container-webhook.fullname" . }}
-rules:
-  - apiGroups: [""]
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ include "harbor-container-webhook.fullname" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "harbor-container-webhook.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "harbor-container-webhook.serviceAccountName" . }}
 ---


### PR DESCRIPTION
When using checkUpstream with authSecretName the controller errors spits out an error with 
`pkg/mod/k8s.io/client-go@v0.30.4/tools/cache/reflector.go:232: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:harbor-container-webhook:harbor-container-webhook" cannot list resource "secrets" in API group "" at the cluster scope`

This addresses it by granting cluster wide secret access to the service account.

Fixes #33 