### PR TITLE
Add imagePullSecrets change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-03-20
+### Added
+- Add imagePullSecrets update when an image is modified
+
 ## [0.8.1] - 2025-03-17
 ### Fixed
 - Fixed chart pdb rendering

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ reference which matches at least one match rule and none of the exclusion rules,
 by the `replace` contents of the rule. If `checkUpstream` is enabled, the webhook will first fetch the manifest
 the rewritten container image reference and verify it exists before rewriting the image.
 
+You can also update the `imagePullSecrets` of a modified pod to have the right docker secret to connect to the modified registry. For that, put `replaceImagePullSecrets` to `true` and be sure that `authSecretName` is set with the Kubernetes secret that you want to add to `imagePullSecrets`. If `imagePullSecrets` already contains a secret, the `authSecretName` will be added to the list anyway.
+
 Example configuration:
 ```yaml
 port: 9443
@@ -67,6 +69,12 @@ rules:
     replace: 'harbor.example.com/ubuntu-proxy'
     checkUpstream: true # tests if the manifest for the rewritten image exists
     authSecretName: harbor-example-image-pull-secret # optional, defaults to "" - secret in the webhook namespace for authenticating to harbor.example.com
+  - name: 'docker.io rewrite rule with imagePullSecrets update'
+    matches:
+      - '^docker.io'
+    replace: 'harbor.example.com/dockerhub-proxy'
+    replaceImagePullSecrets: true # enable imagePullSecrets change for modified images
+    authSecretName: harbor-example-image-pull-secret # secret to add to imagePullSecrets on the modified pod
 ```
 Local Development
 ===

--- a/deploy/charts/harbor-container-webhook/Chart.yaml
+++ b/deploy/charts/harbor-container-webhook/Chart.yaml
@@ -3,7 +3,7 @@ name: harbor-container-webhook
 description: Webhook to configure pods with harbor proxy cache projects
 type: application
 version: 0.8.1
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 kubeVersion: ">= 1.16.0-0"
 home: https://github.com/IndeedEng/harbor-container-webhook
 maintainers:

--- a/deploy/charts/harbor-container-webhook/values.yaml
+++ b/deploy/charts/harbor-container-webhook/values.yaml
@@ -113,6 +113,12 @@ rules: []
 #    platforms: # defaults to linux/amd64, only used if checkUpstream is set
 #      - linux/amd64
 #      - linux/arm64
+#  - name: 'docker.io rewrite rule with imagePullSecrets update'
+#    matches:
+#      - '^docker.io'
+#    replace: 'harbor.example.com/dockerhub-proxy'
+#    replaceImagePullSecrets: true # enable imagePullSecrets change for modified images
+#    authSecretName: harbor-example-image-pull-secret # secret to add to imagePullSecrets on the modified pod
 
 extraRules: []
 

--- a/hack/config.yaml
+++ b/hack/config.yaml
@@ -19,3 +19,10 @@ rules:
     replace: 'harbor-v2.awscmhqa2.k8s.indeed.tech/dockerhub-proxy-auth'
     checkUpstream: true # tests if the manifest for the rewritten image exists
     authSecretName: "harborv2-qa"
+  - name: 'docker.io rewrite rule with imagePullSecret change'
+    # image refs must match at least one of the rules, and not match any excludes
+    matches:
+      - '^docker.io'
+    replace: 'harbor.example.com/dockerhub-proxy'
+    authSecretName: "harborv2-qa"
+    replaceImagePullSecrets: true

--- a/hack/test/admission.json
+++ b/hack/test/admission.json
@@ -13,6 +13,11 @@
       "metadata": {
       },
       "spec": {
+        "imagePullSecrets": [
+          {
+            "name": "foo"
+          }
+        ],
         "containers": [
           {
             "name": "foo",

--- a/hack/test/no-op.json
+++ b/hack/test/no-op.json
@@ -13,6 +13,11 @@
       "metadata": {
       },
       "spec": {
+        "imagePullSecrets": [
+          {
+            "name": "foo"
+          }
+        ],
         "containers": [
           {
             "name": "foo",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,10 +79,13 @@ type ProxyRule struct {
 	// If the webhook lacks permissions to fetch the image manifest or the registry is down, the image
 	// will not be rewritten. Experimental.
 	CheckUpstream bool `yaml:"checkUpstream"`
+	// ReplaceImagePullSecrets enables the replacement of the imagePullSecrets of the pod in addition to the image
+	ReplaceImagePullSecrets bool `yaml:"replaceImagePullSecrets"`
 	// List of the required platforms to check for if CheckUpstream is set. Defaults to "linux/amd64" if unset.
 	Platforms []string `yaml:"platforms"`
 	// AuthSecretName is a reference to an image pull secret (must be .dockerconfigjson type) which
-	// will be used to authenticate if `checkUpstream` is set. Unused if not specified or `checkUpstream` is false.
+	// will be used to authenticate if `checkUpstream` is set or to modify the imagePullSecrets if
+	// `replaceImagePullSecrets` is set.
 	AuthSecretName string `yaml:"authSecretName"`
 	// Namespace that the webhook is running in, used for accessing secrets for authenticated proxy rules
 	Namespace string

--- a/internal/webhook/mutate.go
+++ b/internal/webhook/mutate.go
@@ -47,9 +47,6 @@ func (p *PodContainerProxier) Handle(ctx context.Context, req admission.Request)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	if !updated && !updatedInit {
-		return admission.Allowed("no updates")
-	}
 	pod.Spec.InitContainers = initContainers
 	pod.Spec.Containers = containers
 
@@ -58,10 +55,11 @@ func (p *PodContainerProxier) Handle(ctx context.Context, req admission.Request)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	if !updatedImagePullSecrets {
+	pod.Spec.ImagePullSecrets = imagePullSecrets
+
+	if !updated && !updatedInit && !updatedImagePullSecrets {
 		return admission.Allowed("no updates")
 	}
-	pod.Spec.ImagePullSecrets = imagePullSecrets
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/internal/webhook/mutate.go
+++ b/internal/webhook/mutate.go
@@ -55,7 +55,7 @@ func (p *PodContainerProxier) Handle(ctx context.Context, req admission.Request)
 	}
 
 	// imagePullSecrets
-	imagePullSecrets, _, err := p.updateImagePullSecrets(p.getPodName(pod), pod.Spec.ImagePullSecrets)
+	imagePullSecrets, err := p.updateImagePullSecrets(p.getPodName(pod), pod.Spec.ImagePullSecrets)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
@@ -128,18 +128,18 @@ func (p *PodContainerProxier) InjectDecoder(d admission.Decoder) error {
 	return nil
 }
 
-func (p *PodContainerProxier) updateImagePullSecrets(podName string, imagePullSecrets []corev1.LocalObjectReference) (newImagePullSecrets []corev1.LocalObjectReference, updated bool, err error) {
+func (p *PodContainerProxier) updateImagePullSecrets(podName string, imagePullSecrets []corev1.LocalObjectReference) (newImagePullSecrets []corev1.LocalObjectReference, err error) {
 	for _, transformer := range p.Transformers {
-		updated, newImagePullSecrets, err = transformer.RewriteImagePullSecrets(imagePullSecrets)
+		updated, newImagePullSecrets, err := transformer.RewriteImagePullSecrets(imagePullSecrets)
 		if err != nil {
-			return imagePullSecrets, false, err
+			return imagePullSecrets, err
 		}
 		if !updated {
-			return imagePullSecrets, false, nil
+			return imagePullSecrets, nil
 		}
 		logger.Info(fmt.Sprintf("rewriting the imagePullSecrets of the pod %s from %q to %q", podName, imagePullSecrets, newImagePullSecrets))
 	}
-	return newImagePullSecrets, updated, nil
+	return newImagePullSecrets, nil
 }
 
 func (p *PodContainerProxier) getPodName(pod *corev1.Pod) (podName string) {

--- a/internal/webhook/mutate.go
+++ b/internal/webhook/mutate.go
@@ -129,8 +129,9 @@ func (p *PodContainerProxier) InjectDecoder(d admission.Decoder) error {
 }
 
 func (p *PodContainerProxier) updateImagePullSecrets(podName string, imagePullSecrets []corev1.LocalObjectReference) (newImagePullSecrets []corev1.LocalObjectReference, err error) {
+	updated := false
 	for _, transformer := range p.Transformers {
-		updated, newImagePullSecrets, err := transformer.RewriteImagePullSecrets(imagePullSecrets)
+		updated, newImagePullSecrets, err = transformer.RewriteImagePullSecrets(imagePullSecrets)
 		if err != nil {
 			return imagePullSecrets, err
 		}

--- a/internal/webhook/mutate_test.go
+++ b/internal/webhook/mutate_test.go
@@ -125,29 +125,23 @@ func TestPodContainerProxier_updateImagePullSecretsWithReplaceEnabled(t *testing
 	type testcase struct {
 		name             string
 		imagePullSecrets []corev1.LocalObjectReference
-		platform         string
-		os               string
 		expected         []corev1.LocalObjectReference
 	}
 	tests := []testcase{
 		{
 			name:             "imagePullSecrets is empty, replacement is expected and secret name should be added",
 			imagePullSecrets: []corev1.LocalObjectReference{},
-			os:               "linux",
-			platform:         "amd64",
 			expected:         []corev1.LocalObjectReference{{Name: "secret-test"}},
 		},
 		{
 			name:             "imagePullSecrets has a secret, replacement is expected and secret name should be added",
 			imagePullSecrets: []corev1.LocalObjectReference{{Name: "mysecret"}},
-			os:               "linux",
-			platform:         "amd64",
 			expected:         []corev1.LocalObjectReference{{Name: "mysecret"}, {Name: "secret-test"}},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			newImagePullSecrets, _, err := proxier.updateImagePullSecrets(tc.imagePullSecrets)
+			newImagePullSecrets, _, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, newImagePullSecrets)
 		})
@@ -170,29 +164,23 @@ func TestPodContainerProxier_updateImagePullSecretsWithReplaceDinabled(t *testin
 	type testcase struct {
 		name             string
 		imagePullSecrets []corev1.LocalObjectReference
-		platform         string
-		os               string
 		expected         []corev1.LocalObjectReference
 	}
 	tests := []testcase{
 		{
 			name:             "imagePullSecrets is empty, replacement is not expected",
 			imagePullSecrets: []corev1.LocalObjectReference{},
-			os:               "linux",
-			platform:         "amd64",
 			expected:         []corev1.LocalObjectReference{},
 		},
 		{
 			name:             "imagePullSecrets has a secret, replacement is not expected",
 			imagePullSecrets: []corev1.LocalObjectReference{{Name: "mysecret"}},
-			os:               "linux",
-			platform:         "amd64",
 			expected:         []corev1.LocalObjectReference{{Name: "mysecret"}},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			newImagePullSecrets, _, err := proxier.updateImagePullSecrets(tc.imagePullSecrets)
+			newImagePullSecrets, _, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, newImagePullSecrets)
 		})

--- a/internal/webhook/mutate_test.go
+++ b/internal/webhook/mutate_test.go
@@ -141,7 +141,7 @@ func TestPodContainerProxier_updateImagePullSecretsWithReplaceEnabled(t *testing
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			newImagePullSecrets, _, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
+			newImagePullSecrets, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, newImagePullSecrets)
 		})
@@ -180,7 +180,7 @@ func TestPodContainerProxier_updateImagePullSecretsWithReplaceDinabled(t *testin
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			newImagePullSecrets, _, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
+			newImagePullSecrets, err := proxier.updateImagePullSecrets("pod-test", tc.imagePullSecrets)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, newImagePullSecrets)
 		})


### PR DESCRIPTION
Based on a need that we currently have, this PR adds the modification of the `imagePullSecrets` of a pod where an image have been updated. It permits to avoid adding (or missing :smile:) this secret on all the releases/deployments of a kube cluster using the harbor mutating webhook

It adds the boolean parameter `replaceImagePullSecrets` in the configuration which will be used with `authSecretName` to add this secret to the `imagePullSecrets` of the pod. To avoid any errors, it keep the existing secrets that are already in `imagePullSecrets` and only adds the new one.

I'm not a Go expert, so feel free to give me feedbacks and improvements that can be made on the code.

https://github.com/indeedeng/harbor-container-webhook/issues/52

