### PR TITLE
Add method to skip wrong reference format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2025-03-26
+### Fixed
+- Fixed wrong image reference handling
+
 ## [0.8.1] - 2025-03-17
 ### Fixed
 - Fixed chart pdb rendering

--- a/internal/webhook/docker.go
+++ b/internal/webhook/docker.go
@@ -11,6 +11,12 @@ import (
 
 const BareRegistry = "docker.io"
 
+// CheckImageRefFormat returns a boolean that validates or not the image ref format.
+func CheckImageRefFormat(imageReference string) (valid bool) {
+	_, err := reference.Parse(imageReference)
+	return err == nil
+}
+
 // RegistryFromImageRef returns the registry (and port, if set) from the image reference,
 // otherwise returns the default bare registry, "docker.io".
 func RegistryFromImageRef(imageReference string) (registry string, err error) {

--- a/internal/webhook/mutate_test.go
+++ b/internal/webhook/mutate_test.go
@@ -84,6 +84,13 @@ func TestPodContainerProxier_rewriteImage(t *testing.T) {
 			expected: "harbor.example.com/dockerhub-proxy/library/centos:latest",
 		},
 		{
+			name:     "a wrong format image should not be rewritten",
+			image:    "docker.io/library/centos:",
+			os:       "linux",
+			platform: "amd64",
+			expected: "docker.io/library/centos:",
+		},
+		{
 			name:     "an image from gcr should not be rewritten",
 			image:    "k8s.gcr.io/kubernetes",
 			os:       "linux",

--- a/internal/webhook/transformer.go
+++ b/internal/webhook/transformer.go
@@ -237,6 +237,12 @@ func (t *ruleTransformer) RewriteImage(imageRef string) (string, error) {
 }
 
 func (t *ruleTransformer) doRewriteImage(imageRef string) (rewritten bool, updatedRef string, err error) {
+	isValidFormat := CheckImageRefFormat(imageRef)
+	if !isValidFormat {
+		logger.Info(fmt.Sprintf("Image ref format %s is not valid, skip it", imageRef))
+		return false, imageRef, nil
+	}
+
 	registry, err := RegistryFromImageRef(imageRef)
 	if err != nil {
 		return false, "", err


### PR DESCRIPTION
**Observation**
When an image reference format is wrong, the mutating webhook is failing and the deployment cannot go further. Even if the regex does not include this image.

I think that it should be great to skip that case and let the mutating webhook deploies this deployment anyway.

I detected that in a case where ArgoCD + Image updater need to deploy a pod without tag before finding / applying a new tag. So without this the ArgoCD deployments could be broken

**Solution**

Add a method to verify the reference format, if it's wrong, just skip the mutating webhook changes and return the same imageRef

**Tests**
- unit test for this case is done
- I have tested it in a real environment and it works as expected